### PR TITLE
Upgrade to v4 of upload-artifact

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
         semgrep --config=auto --json --output=semgrep-report.json . || true
     
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: security-reports
         path: |


### PR DESCRIPTION
Resolved the error below for Deprecated version of `upload-artifact`:
`Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`

### Solution
Resolved by upgrading the `upload-artifact` version from **`v3 `** to **`v4`**